### PR TITLE
making sure totalSpent doesn't have the extra 0's

### DIFF
--- a/dataLayer-allPages.js
+++ b/dataLayer-allPages.js
@@ -245,7 +245,7 @@ applyBindings(defaultBindings, __bva__);
         'country'     : '{{customer_address.country}}',
         'phone'       : '{{customer_address.phone}}',
         'totalOrders' : '{{customer.orders_count}}',
-        'totalSpent'  : '{{customer.total_spent}}'
+        'totalSpent'  : '{{customer.total_spent | money_without_currency}}'
       },
       {% else %}
       'logState' : "Logged Out",


### PR DESCRIPTION
Added `money_without_currency` filter to `totalSpent` for `customerInfo` to remove the extra two 0's